### PR TITLE
Make icomplete-selected-match more visible

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -666,6 +666,7 @@ Must be one of `mocha`, `macchiato`, `frappe`, or `latte`."
                (icicle-annotation :foreground ,ctp-overlay2)
                ;; icomplete
                (icompletep-determined :foreground ,ctp-blue)
+               (icomplete-selected-match :inherit match)
                ;; ido
                (ido-first-match :foreground ,ctp-green)
                (ido-only-match :foreground ,ctp-green)


### PR DESCRIPTION
When using icomplete, the selected match highlight is almost invisible. This PR makes it more visible by changing from `highlight` to `match` face.

![Screenshot 2023-12-11 204356](https://github.com/catppuccin/emacs/assets/782760/7e324d21-5482-44e7-bf9c-79982ebf1dc3)
![Screenshot 2023-12-11 204618](https://github.com/catppuccin/emacs/assets/782760/b80582ce-cc34-4d2c-a8c3-a29c3e659075)
