### PR TITLE
chore: bump Emacs to 27.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Install Emacs 26
+      - name: Install Emacs 27
         run: |
-          wget https://security.debian.org/debian-security/pool/updates/main/e/emacs/emacs_26.1+1-3.2+deb10u6_all.deb https://mirrors.kernel.org/ubuntu/pool/universe/c/compat-el/elpa-compat_29.1.4.4+dfsg-1_all.deb
-          sudo apt install --allow-downgrades ./emacs_26.1+1-3.2+deb10u6_all.deb ./elpa-compat_29.1.4.4+dfsg-1_all.deb
+          wget https://security.debian.org/debian-security/pool/updates/main/e/emacs/emacs_27.1+1-3.1+deb11u6_all.deb https://mirrors.kernel.org/ubuntu/pool/universe/c/compat-el/elpa-compat_29.1.4.4+dfsg-1_all.deb
+          sudo apt install --allow-downgrades ./emacs_27.1+1-3.1+deb11u6_all.deb ./elpa-compat_29.1.4.4+dfsg-1_all.deb
 
       - name: Install Just
         uses: extractions/setup-just@v2

--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -25,7 +25,7 @@
 ;; Author: nyxkrage
 ;; Original-Author: film42
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "27.1"))
 ;; URL: https://github.com/catppuccin/emacs
 
 ;;; Commentary:


### PR DESCRIPTION
Emacs 26 debs were removed

cc @nyxkrage @sgoudham