### PR TITLE
fix: Display error in centaur-tabs-set-bar

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1242,10 +1242,6 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
            :background ,ctp-mantle)
          (centaur-tabs-selected-modified :foreground ,ctp-red
            :background ,ctp-current)
-         (centaur-tabs-close-unselected :foreground ,ctp-subtext0
-           :background ,ctp-mantle)
-         (centaur-tabs-close-selected :foreground ,ctp-text
-           :background ,ctp-current)
          (centaur-tabs-name-mouse-face :foreground ,ctp-text
            :background ,ctp-surface1)
          (centaur-tabs-close-mouse-face :foreground ,ctp-red


### PR DESCRIPTION
### Old:

<!--Provide a screenshot of the original issue if applicable:
  ![original-screenshot-here](Please)
-->
<img width="238" height="61" alt="图片" src="https://github.com/user-attachments/assets/c2fcb87a-419b-4ea8-b3eb-1baafc6a1b87" />

### New:

<!--Provide a screenshot of your changes if applicable:
  ![original-screenshot-here](Please)
-->
<img width="212" height="53" alt="图片" src="https://github.com/user-attachments/assets/01c102b1-19da-42a5-8bc1-e55d4d71ec5f" />
