### PR TITLE
Added Ediff support

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -509,6 +509,20 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (diff-refine-changed :background ,ctp-yellow
            :foreground ,ctp-base)
 
+         ;; ediff
+         (ediff-current-diff-A :background ,ctp-surface0 :foreground ,ctp-red :extend t)
+         (ediff-current-diff-B :background ,ctp-surface0 :foreground ,ctp-green :extend t)
+         (ediff-current-diff-C :background ,ctp-surface0 :foreground ,ctp-yellow :extend t)
+         (ediff-even-diff-A :background ,ctp-mantle :extend t)
+         (ediff-even-diff-B :background ,ctp-mantle :extend t)
+         (ediff-even-diff-C :background ,ctp-mantle :extend t)
+         (ediff-odd-diff-A :background ,ctp-surface0 :extend t)
+         (ediff-odd-diff-B :background ,ctp-surface0 :extend t)
+         (ediff-odd-diff-C :background ,ctp-surface0 :extend t)
+         (ediff-fine-diff-A :background ,ctp-surface1 :foreground ,ctp-red :weight bold :extend t)
+         (ediff-fine-diff-B :background ,ctp-surface1 :foreground ,ctp-green :weight bold :extend t)
+         (ediff-fine-diff-C :background ,ctp-surface1 :foreground ,ctp-yellow :weight bold :extend t)
+
          ;; eshell
          (eshell-ls-archive :foreground ,ctp-mauve)
          (eshell-ls-backup :foreground ,ctp-yellow)


### PR DESCRIPTION
Currently there is no support for ediff.

This PR adds the ediff support.

Here is the difference before/after:

## Old:
<img width="1718" height="1048" alt="Screenshot 2026-03-04 at 23 24 50" src="https://github.com/user-attachments/assets/6914b650-6a94-4a1c-bd46-ad089a7b46af" />


## New:
<img width="1716" height="1054" alt="Screenshot 2026-03-04 at 23 16 46" src="https://github.com/user-attachments/assets/5cae3d47-df7d-4912-a7ff-a5529bd9c43a" />

