### PR TITLE
fix: ctp-linum missing TTY entry causes nil background on line-number faces

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -317,7 +317,10 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
               (catppuccin-lighten (catppuccin-color 'base) 17))))
         (ctp-linum (if catppuccin-dark-line-numbers-background
                      (catppuccin-color 'mantle)
-                     (catppuccin-color 'base)))))
+                     (or (catppuccin-color 'base) 'unspecified))
+          (if catppuccin-dark-line-numbers-background
+            (catppuccin-quantize-color (catppuccin-color 'mantle))
+            (or (catppuccin-quantize-color (catppuccin-color 'base)) 'unspecified)))))
     (faces
       '(
          ;; default / basic faces


### PR DESCRIPTION
## Problem

Loading `catppuccin-theme` produces the following warning for all users
(GUI, true-color TTY, and 256-color TTY alike):

```
Warning (faces): In face `line-number': setting attribute
`:background' of face `line-number': nil value is invalid
```

## Root cause

Each color entry in the `colors` binding has three elements:

```
(SYMBOL  24BIT-EXPR  256COLOR-EXPR)
```

Face specs are built with both a true-color branch and a 256-color
fallback branch:

```elisp
((((min-colors 16777216))   ; true-color → cadr → 24-bit hex
   ,(funcall expand-with-func 'cadr spec))
 (t                         ; 256-color fallback → caddr → quantized
   ,(funcall expand-with-func '(lambda (v) (cadr (cdr v))) spec)))
```

Both branches are expanded **statically at theme load time**.  `ctp-linum`
only had two elements `(SYMBOL 24BIT-EXPR)`, so `caddr` returned `nil`
for the 256-color branch.  That `nil` was baked into the face spec, and
Emacs validates all branches when a face spec is set — so the warning
fires regardless of the actual display type.

Note: at rendering time, true-color terminals (those satisfying
`(min-colors 16777216)`) correctly use the 24-bit branch and never
reach the nil value.  But the warning fires unconditionally at load
time because both branches are already fully expanded.

## Fix

Two changes to `ctp-linum`:

1. **Add the missing 3rd element** — the quantized color expression,
   mirroring the logic of the 24-bit path but using
   `catppuccin-quantize-color`.

2. **Guard both paths with `(or ... 'unspecified)`** — if
   `catppuccin-color` returns `nil` (which can happen for `'base` in
   certain configurations), fall back to the symbol `'unspecified`
   rather than `nil`.  Emacs requires the symbol `unspecified` to mean
   "no value"; `nil` is not accepted for face attributes.

```elisp
;; before
(ctp-linum (if catppuccin-dark-line-numbers-background
             (catppuccin-color 'mantle)
             (catppuccin-color 'base)))))

;; after
(ctp-linum (if catppuccin-dark-line-numbers-background
             (catppuccin-color 'mantle)
             (or (catppuccin-color 'base) 'unspecified))
           (if catppuccin-dark-line-numbers-background
             (catppuccin-quantize-color (catppuccin-color 'mantle))
             (or (catppuccin-quantize-color (catppuccin-color 'base)) 'unspecified)))))
```

## How to reproduce (before fix)

1. Load `catppuccin-theme` and enable any flavor, in any Emacs session
   (GUI, true-color TTY, or 256-color TTY).
2. Check `*Messages*` — the `:background nil` warning appears.
